### PR TITLE
Sort cars by multiplier & add author's field

### DIFF
--- a/app/controllers/cars_controller.rb
+++ b/app/controllers/cars_controller.rb
@@ -211,6 +211,6 @@ class CarsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def car_params
-    params.require(:car).permit(:name, :speed, :accel, :weight, :multiplier, :folder_name, :category, :stock, :season)
+    params.require(:car).permit(:name, :speed, :accel, :weight, :multiplier, :folder_name, :category, :author, :stock, :season)
   end
 end

--- a/app/controllers/cars_controller.rb
+++ b/app/controllers/cars_controller.rb
@@ -19,7 +19,7 @@ class CarsController < ApplicationController
   # GET /cars/rookie or /cars/rookie.json
   def rookie
     @cars = Rails.cache.fetch('rookie_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::ROOKIE).sort_by(&:multiplier)
+      @cars = cars_of_category(SYS::CATEGORY::ROOKIE).sort_by { |car| [car.multiplier, car.stock? ? 0 : 1] }
     end
 
     respond_with @cars do |format|
@@ -30,7 +30,7 @@ class CarsController < ApplicationController
   # GET /cars/amateur or /cars/amateur.json
   def amateur
     @cars = Rails.cache.fetch('amateur_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::AMATEUR).sort_by(&:multiplier)
+      @cars = cars_of_category(SYS::CATEGORY::AMATEUR).sort_by { |car| [car.multiplier, car.stock? ? 0 : 1] }
     end
 
     respond_with @cars do |format|
@@ -41,7 +41,7 @@ class CarsController < ApplicationController
   # GET /cars/advanced or /cars/advanced.json
   def advanced
     @cars = Rails.cache.fetch('advanced_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::ADVANCED).sort_by(&:multiplier)
+      @cars = cars_of_category(SYS::CATEGORY::ADVANCED).sort_by { |car| [car.multiplier, car.stock? ? 0 : 1] }
     end
 
     respond_with @cars do |format|
@@ -52,7 +52,7 @@ class CarsController < ApplicationController
   # GET /cars/semipro or /cars/semipro.json
   def semipro
     @cars = Rails.cache.fetch('semipro_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::SEMI_PRO).sort_by(&:multiplier)
+      @cars = cars_of_category(SYS::CATEGORY::SEMI_PRO).sort_by { |car| [car.multiplier, car.stock? ? 0 : 1] }
     end
 
     respond_with @cars do |format|
@@ -63,7 +63,7 @@ class CarsController < ApplicationController
   # GET /cars/pro or /cars/pro.json
   def pro
     @cars = Rails.cache.fetch('pro_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::PRO).sort_by(&:multiplier)
+      @cars = cars_of_category(SYS::CATEGORY::PRO).sort_by { |car| [car.multiplier, car.stock? ? 0 : 1] }
     end
 
     respond_with @cars do |format|
@@ -74,7 +74,7 @@ class CarsController < ApplicationController
   # GET /cars/superpro or /cars/superpro.json
   def superpro
     @cars = Rails.cache.fetch('superpro_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::SUPER_PRO).sort_by(&:multiplier)
+      @cars = cars_of_category(SYS::CATEGORY::SUPER_PRO).sort_by { |car| [car.multiplier, car.stock? ? 0 : 1] }
     end
 
     respond_with @cars do |format|
@@ -85,7 +85,7 @@ class CarsController < ApplicationController
   # GET /cars/clockwork or /cars/clockwork.json
   def clockwork
     @cars = Rails.cache.fetch('clockwork_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::CLOCKWORK).sort_by(&:multiplier)
+      @cars = cars_of_category(SYS::CATEGORY::CLOCKWORK).sort_by { |car| [car.multiplier, car.stock? ? 0 : 1] }
     end
 
     respond_with @cars do |format|

--- a/app/controllers/cars_controller.rb
+++ b/app/controllers/cars_controller.rb
@@ -19,7 +19,7 @@ class CarsController < ApplicationController
   # GET /cars/rookie or /cars/rookie.json
   def rookie
     @cars = Rails.cache.fetch('rookie_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::ROOKIE)
+      @cars = cars_of_category(SYS::CATEGORY::ROOKIE).sort_by(&:multiplier)
     end
 
     respond_with @cars do |format|
@@ -30,7 +30,7 @@ class CarsController < ApplicationController
   # GET /cars/amateur or /cars/amateur.json
   def amateur
     @cars = Rails.cache.fetch('amateur_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::AMATEUR)
+      @cars = cars_of_category(SYS::CATEGORY::AMATEUR).sort_by(&:multiplier)
     end
 
     respond_with @cars do |format|
@@ -41,7 +41,7 @@ class CarsController < ApplicationController
   # GET /cars/advanced or /cars/advanced.json
   def advanced
     @cars = Rails.cache.fetch('advanced_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::ADVANCED)
+      @cars = cars_of_category(SYS::CATEGORY::ADVANCED).sort_by(&:multiplier)
     end
 
     respond_with @cars do |format|
@@ -52,7 +52,7 @@ class CarsController < ApplicationController
   # GET /cars/semipro or /cars/semipro.json
   def semipro
     @cars = Rails.cache.fetch('semipro_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::SEMI_PRO)
+      @cars = cars_of_category(SYS::CATEGORY::SEMI_PRO).sort_by(&:multiplier)
     end
 
     respond_with @cars do |format|
@@ -63,7 +63,7 @@ class CarsController < ApplicationController
   # GET /cars/pro or /cars/pro.json
   def pro
     @cars = Rails.cache.fetch('pro_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::PRO)
+      @cars = cars_of_category(SYS::CATEGORY::PRO).sort_by(&:multiplier)
     end
 
     respond_with @cars do |format|
@@ -74,7 +74,7 @@ class CarsController < ApplicationController
   # GET /cars/superpro or /cars/superpro.json
   def superpro
     @cars = Rails.cache.fetch('superpro_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::SUPER_PRO)
+      @cars = cars_of_category(SYS::CATEGORY::SUPER_PRO).sort_by(&:multiplier)
     end
 
     respond_with @cars do |format|
@@ -85,7 +85,7 @@ class CarsController < ApplicationController
   # GET /cars/clockwork or /cars/clockwork.json
   def clockwork
     @cars = Rails.cache.fetch('clockwork_cars', :expires_in => 1.month) do
-      @cars = cars_of_category(SYS::CATEGORY::CLOCKWORK)
+      @cars = cars_of_category(SYS::CATEGORY::CLOCKWORK).sort_by(&:multiplier)
     end
 
     respond_with @cars do |format|

--- a/app/models/car.rb
+++ b/app/models/car.rb
@@ -13,6 +13,7 @@ class Car
   field :multiplier, :type => Float
   field :folder_name, :type => String
   field :category, :type => Integer
+  field :author, :type => String
   field :stock, :type => Boolean, :default => false
 
   validates_presence_of :name
@@ -22,6 +23,7 @@ class Car
   validates_presence_of :multiplier
   validates_presence_of :folder_name
   validates_presence_of :category
+  validates_presence_of :author
   validates_presence_of :stock
 
   def thumbnail_url

--- a/app/services/csv_import_cars_service.rb
+++ b/app/services/csv_import_cars_service.rb
@@ -34,7 +34,8 @@ class CsvImportCarsService
         :weight => row[3],
         :multiplier => row[4],
         :folder_name => row[5],
-        :stock => true?(row[6])
+        :author => row[6],
+        :stock => true?(row[7])
       }
 
       cars << Car.new(car_hash)

--- a/app/views/cars/_car.json.jbuilder
+++ b/app/views/cars/_car.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! car, :id, :name, :speed, :accel, :weight, :multiplier, :category, :stock, :folder_name, :created_at,
+json.extract! car, :id, :name, :speed, :accel, :weight, :multiplier, :category, :author, :stock, :folder_name, :created_at,
               :updated_at
 json.url car_url(car, :format => :json)

--- a/app/views/cars/edit.haml
+++ b/app/views/cars/edit.haml
@@ -33,7 +33,7 @@
         = f.label :folder_name, t("rva.cars.edit.folder-name")
         = f.text_field :folder_name, :class => "form-control"
       .field-form-group
-        = f.label :author, "Author"
+        = f.label :author, t("rva.cars.features.author")
         = f.text_field :author, :class => "form-control"
       .field.form-group
         = f.label :stock, t("rva.cars.features.stock")

--- a/app/views/cars/edit.haml
+++ b/app/views/cars/edit.haml
@@ -32,6 +32,9 @@
       .field.form-group
         = f.label :folder_name, t("rva.cars.edit.folder-name")
         = f.text_field :folder_name, :class => "form-control"
+      .field-form-group
+        = f.label :author, "Author"
+        = f.text_field :author, :class => "form-control"
       .field.form-group
         = f.label :stock, t("rva.cars.features.stock")
         = f.check_box :stock

--- a/app/views/cars/show.haml
+++ b/app/views/cars/show.haml
@@ -37,6 +37,10 @@
             = t("rva.cars.features.category")
           %dd
             = category_name(@car.category)
+          %dt
+            = "Author"
+          %dd
+            = @car.author
           %dt{:style => "cursor: help;", :"data-toggle" => "tooltip", :"data-placement" => "top", :title => t("rva.cars.features.stock-tooltip.tooltip")}
             = t("rva.shared.stock.title")
           %dd

--- a/app/views/cars/show.haml
+++ b/app/views/cars/show.haml
@@ -38,7 +38,7 @@
           %dd
             = category_name(@car.category)
           %dt
-            = "Author"
+            = t("rva.cars.features.author")
           %dd
             = @car.author
           %dt{:style => "cursor: help;", :"data-toggle" => "tooltip", :"data-placement" => "top", :title => t("rva.cars.features.stock-tooltip.tooltip")}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,6 +425,7 @@ en:
         weight: "Weight"
         multiplier: "Multiplier"
         category: "Category"
+        author: "Author"
         stock: "Stock"
         stock-tooltip:
           tooltip: "Original Re-Volt Content"


### PR DESCRIPTION
When updating the multipliers of the cars, the order of these were not reflected correctly. #92 #94

![image](https://github.com/Re-Volt-America/RVA/assets/137591602/416b1e61-845a-4151-b25d-f2e7c56caee0)


I have modified the controller, so is always ordered from the lowest to the highest multiplier in each category.