### PR TITLE
Session CSV parser support for Unix OS date format

### DIFF
--- a/app/services/csv_import_sessions_service.rb
+++ b/app/services/csv_import_sessions_service.rb
@@ -35,7 +35,7 @@ class CsvImportSessionsService
       raise ArgumentError, "Unrecognised date format"
     end
   
-    parsed_date.strftime('%m/%d/%y')
+    parsed_date
   end
 
   def call

--- a/app/services/csv_import_sessions_service.rb
+++ b/app/services/csv_import_sessions_service.rb
@@ -14,6 +14,30 @@ class CsvImportSessionsService
     @teams = teams
   end
 
+  def parse_and_format_date(date_string)
+    formats = [
+      '%D',                       # Expected format 'mm/dd/yy H:mm:ss' from Windows machines
+      '%a %b %e %H:%M:%S %Y'      # Expected format 'ddd mmm d H:mm:ss yyyy' from Unix machines
+    ]
+  
+    parsed_date = nil
+  
+    formats.each do |format|
+      begin
+        parsed_date = Date.strptime(date_string, format)
+        break
+      rescue ArgumentError
+        next
+      end
+    end
+  
+    if parsed_date.nil?
+      raise ArgumentError, "Unrecognised date format"
+    end
+  
+    parsed_date.strftime('%m/%d/%y')
+  end
+
   def call
     csv = CSV.parse(File.open(@file))
 
@@ -33,7 +57,7 @@ class CsvImportSessionsService
       :physics => session_arr[1][3],
       :protocol => session_arr[0][2],
       :pickups => true?(session_arr[1][5]),
-      :date => Date.strptime(session_arr[1][1], '%D'),
+      :date => parse_and_format_date(session_arr[1][1]),
       :races => get_races_hash(session_arr),
       :ranking => @ranking,
       :category => @category,


### PR DESCRIPTION
Creates a compatibility for Unix machine session date parsing, given that they generate the CSV date in a different format.
Saves date in the format of mm/dd/yy, regardless of input format.
Windows format example:
![Screenshot_20240804_004636](https://github.com/user-attachments/assets/0cb989f9-129a-4edb-958c-c999b780b794)

Unix format example:
![Screenshot_20240804_004731](https://github.com/user-attachments/assets/8ba0e3f0-8417-4861-bdc4-f94c8d419365)
