### PR TITLE
Add shortcut link for current ranking in League menu (Issue #175)

### DIFF
--- a/app/views/application/_nav.haml
+++ b/app/views/application/_nav.haml
@@ -29,6 +29,11 @@
             %i.fa.fa-trophy{:"aria-hidden" => true}
             = t("nav.league.title")
           %div.dropdown-menu{:"aria-labelledby" => "dropdown01"}
+            - if current_ranking
+              %a.dropdown-item{:href => ranking_path(current_ranking)}
+                %i.fa.fa-crosshairs{:"aria-hidden" => "true"}
+                = t("nav.league.current-ranking")
+              %div.dropdown-divider
             %a.dropdown-item{:href => stats_path}
               %i.fa.fa-line-chart{:"aria-hidden" => "true"}
               = t("nav.league.leaderboard")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
     seasons: "Seasons"
     league:
       title: "League"
+      current-ranking: "Current Ranking"
       leaderboard: "Leaderboard"
       point-system: "Points System"
       teams: "Teams"

--- a/config/locales/en_gb.yml
+++ b/config/locales/en_gb.yml
@@ -7,6 +7,7 @@ en-GB:
     seasons: "Seasons"
     league:
       title: "League"
+      current-ranking: "Current Ranking"
       leaderboard: "Leaderboard"
       point-system: "Points System"
       teams: "Teams"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,6 +7,7 @@ es:
     seasons: "Temporadas"
     league:
       title: "Liga"
+      current-ranking: "Ranking Actual"
       leaderboard: "Tabla de Posiciones"
       point-system: "Sistema de Puntos"
       teams: "Equipos"

--- a/config/locales/es_ar.yml
+++ b/config/locales/es_ar.yml
@@ -7,6 +7,7 @@ es-AR:
     seasons: "Temporadas"
     league:
       title: "Liga"
+      current-ranking: "Ranking Actual"
       leaderboard: "Tabla de Posiciones"
       point-system: "Sistema de Puntos"
       teams: "Equipos"

--- a/config/locales/es_cl.yml
+++ b/config/locales/es_cl.yml
@@ -7,6 +7,7 @@ es-CL:
     seasons: "Temporadas"
     league:
       title: "Liga"
+      current-ranking: "Ranking Actual"
       leaderboard: "Tabla de Posiciones"
       point-system: "Sistema de Puntos"
       teams: "Equipos"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -7,6 +7,7 @@ it:
     seasons: "Stagioni"
     league:
       title: "Lega"
+      current-ranking: "Ranking Attuale"
       leaderboard: "Classifica"
       point-system: "Sistema di punteggio"
       teams: "Squadra"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -7,6 +7,7 @@ ko:
     seasons: "시즌"
     league:
       title: "리그"
+      current-ranking: "현재 순위"
       leaderboard: "순위표"
       point-system: "포인트 시스템"
       teams: "팀"

--- a/config/locales/lol.yml
+++ b/config/locales/lol.yml
@@ -7,6 +7,7 @@ lol:
     seasons: "Seazuns"
     league:
       title: "LOL"
+      current-ranking: "CURRUNT RANK"
       leaderboard: "Katbod"
       point-system: "Pontz systm"
       teams: "Teamz"

--- a/config/locales/pt_br.yml
+++ b/config/locales/pt_br.yml
@@ -7,6 +7,7 @@ pt:
     seasons: "Temporadas"
     league:
       title: "Ligas"
+      current-ranking: "Ranking Atual"
       leaderboard: "Tabela de classificação"
       point-system: "Sistema de Pontos"
       teams: "Equipes"


### PR DESCRIPTION
- Add 'Current Ranking' dropdown menu item in League section
- Link to current ranking page only when an active ranking exists
- Add visual separator (dropdown-divider) for better UX
- Add translation keys for all 9 supported languages

Closes #175